### PR TITLE
fix: Windows compatibility in web UI and scan module

### DIFF
--- a/scan/__main__.py
+++ b/scan/__main__.py
@@ -98,10 +98,19 @@ def run_one(language, rest_args, base_output):
         call_args = strip_output_args(call_args)
         call_args += ['--output', output_path]
 
+    # Force UTF-8 on both ends of the pipe. The default on Windows is the
+    # system code page (cp1252/cp936/...), which can't encode non-ASCII
+    # scanner output (typographic quotes in snippets, CJK paths, etc.).
+    env = os.environ.copy()
+    env.setdefault('PYTHONIOENCODING', 'utf-8')
+
     proc = subprocess.run(cmd + call_args,
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE,
-                          text=True)
+                          text=True,
+                          encoding='utf-8',
+                          errors='replace',
+                          env=env)
 
     return {
         'language': language,

--- a/web/server.py
+++ b/web/server.py
@@ -164,18 +164,19 @@ def scan_dir(prj_path, target_march, git_info= None, report_format='json', langu
             git_params += ['--branch', git_info['branch']]
 
     def build_cmd(cat, out_file, report_format):
-        fmt_params = ' --output-format ' + report_format
+        # Build an argv list (not a shell string) and run with shell=False so
+        # the command works on Windows too. Use sys.executable instead of a
+        # hardcoded 'python3' (which may not exist on Windows) and os.path.join
+        # so the script path uses the platform's native separator.
+        main_py = os.path.join(env['PYTHONPATH'], cat, '__main__.py')
+        cmd = [sys.executable, main_py] + git_params + [
+            '--output', out_file,
+            '--output-format', report_format,
+        ]
         if cat == 'cpp':
-            return ['python3 ' + env['PYTHONPATH'] + '/' + cat + '/__main__.py ' +
-                    ' '.join(git_params) +
-                    ' --output ' + out_file +
-                    fmt_params +
-                    ' --warning-level L2 --march ' + target_march + ' .']
-        return ['python3 ' + env['PYTHONPATH'] + '/' + cat + '/__main__.py ' +
-                ' '.join(git_params) +
-                ' --output ' + out_file +
-                fmt_params +
-                ' --march ' + target_march + ' .']
+            cmd += ['--warning-level', 'L2']
+        cmd += ['--march', target_march, '.']
+        return cmd
 
     def enqueue_cat(cat):
         # Always generate JSON for /result page rendering
@@ -214,7 +215,7 @@ def scan_dir(prj_path, target_march, git_info= None, report_format='json', langu
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 universal_newlines=True,
-                shell=True
+                shell=False
             )
             while True:
                 output = process.stdout.readline()


### PR DESCRIPTION
web/server.py:
Restore the cross-platform fix from #48 (3ffc8a7) that #57 (763e677) inadvertently reverted while adding the report-format selector. Use sys.executable + os.path.join with shell=False so the scanner runs on Windows where the hardcoded 'python3' command does not exist.

scan/__main__.py:
Force UTF-8 on the scanner subprocess pipe. The default pipe encoding on Windows is the system code page (cp1252/cp936/...), which cannot encode non-ASCII scanner output (typographic quotes in snippets, CJK paths, etc.) and crashes the child with UnicodeEncodeError.


Change-Id: Ica5223ab0a29ad4a80dfc76f1610c5bd7a3cbac8